### PR TITLE
Check build environment for conditions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,28 @@ AS_IF([test "x$wantfldigixmlrpc" = xtrue], [
 	dnl else Fldigi XML RPC not wanted
 	AC_MSG_RESULT([no])])
 
+dnl Check operating system
+AC_CANONICAL_HOST
+
+# Detect the target system
+case "${host_os}" in
+	linux*)
+	    AC_DEFINE([HAVE_LINUX], [1],
+		[Define to 1 if OS is Linux.])
+	    ;;
+	freebsd*)
+	    AC_DEFINE([HAVE_FREEBSD], [1],
+		[Define to 1 if OS is FreeBSD.])
+	    ;;
+	darwin*)
+	    AC_DEFINE([HAVE_OSX], [1],
+		[Define to 1 if OS is OSX.])
+	    ;;
+	*)
+	AC_MSG_ERROR(["OS $host_os is not supported"])
+	;;
+esac
+
 
 dnl Set warnings for compilation
 dnl CFLAGS is reserved for user, so set the AM_* counterpart.

--- a/src/main.c
+++ b/src/main.c
@@ -550,8 +550,10 @@ void ui_init() {
     } else if (strcasecmp(term, "xterm") == 0) {
 	use_xterm = 1;
 	use_rxvt = 1;
+#ifdef HAVE_LINUX
     } else
 	putenv("TERM=rxvt");	/*or going to native console linux driver */
+#endif
 
     /* Check the environment variable ESCDELAY.
      *

--- a/src/main.c
+++ b/src/main.c
@@ -553,6 +553,8 @@ void ui_init() {
 #ifdef HAVE_LINUX
     } else
 	putenv("TERM=rxvt");	/*or going to native console linux driver */
+#elif
+    }
 #endif
 
     /* Check the environment variable ESCDELAY.


### PR DESCRIPTION
I saw your PR, and there is the another one ([#99](https://github.com/Tlf/tlf/pull/99)), and perhaps it would be good to check, what is the build environment. Most Tlf developer uses Linux (as I know :)), and can check only its own system. This patch is just a small example to check the host_os env in autoconf, and use the result. I think we can use it in case of #99 PR.

This is just an example, I think we must review the host_os strings.